### PR TITLE
Fix iframe mouse wheel in safari <= 8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^1.0.1",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-toolbar": "PolymerElements/paper-toolbar#^1.0.0",
+    "paper-tabs": "PolymerElements/paper-tabs#^1.0.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "hydrolysis": "Polymer/hydrolysis#^1.18",
     "paper-header-panel": "PolymerElements/paper-header-panel#^1.0.0",

--- a/iron-component-page.css
+++ b/iron-component-page.css
@@ -111,11 +111,6 @@ paper-toolbar a:hover, paper-toolbar a:hover iron-icon, paper-toolbar a.iron-sel
   background: transparent;
 }
 
-#active paper-tab {
-  padding: 0 6px;
-  width: auto;
-}
-
 paper-toolbar a {
   font-size: 14px;
   text-transform: uppercase;

--- a/iron-component-page.css
+++ b/iron-component-page.css
@@ -105,10 +105,15 @@ paper-toolbar a:hover, paper-toolbar a:hover iron-icon, paper-toolbar a.iron-sel
 }
 
 #active {
-  font-size: 20px;
+  font-size: 16px;
   font-family: Roboto, Noto;
   border: 0;
   background: transparent;
+}
+
+#active paper-tab {
+  padding: 0 6px;
+  width: auto;
 }
 
 paper-toolbar a {

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -15,6 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="../paper-header-panel/paper-header-panel.html">
 <link rel="import" href="../paper-toolbar/paper-toolbar.html">
+<link rel="import" href="../paper-tabs/paper-tabs.html">
+<link rel="import" href="../paper-tabs/paper-tab.html">
 <link rel="import" href="../paper-styles/paper-styles.html">
 
 <!--
@@ -32,13 +34,14 @@ documentation page including demos (if available).
       <paper-toolbar catalog-hidden>
         <div class="flex">
           <!-- TODO: Replace with paper-dropdown-menu when available -->
-          <select id="active" value="{{active::change}}">
+          <paper-tabs scrollable id="active" selected="{{active::change}}">
             <template is="dom-repeat" items="[[docElements]]">
-              <option value="[[item.is]]">[[item.is]]</option>
+              <paper-tab value="[[item.is]]">[[item.is]]</paper-tab>
             </template>
             <template is="dom-repeat" items="[[docBehaviors]]">
-              <option value="[[item.is]]">[[item.is]]</option>
+              <paper-tab value="[[item.is]]">[[item.is]]</paper-tab>
             </template>
+          </paper-tabs>
           </select>
         </div>
         <iron-selector attr-for-selected="view" selected="{{view}}" id="links" hidden$="[[!docDemos.length]]">

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -34,7 +34,7 @@ documentation page including demos (if available).
       <paper-toolbar catalog-hidden>
         <div class="flex">
           <!-- TODO: Replace with paper-dropdown-menu when available -->
-          <paper-tabs scrollable id="active" selected="{{active::change}}">
+          <paper-tabs scrollable id="active" attr-for-selected="value" selectable selected="{{active}}">
             <template is="dom-repeat" items="[[docElements]]">
               <paper-tab value="[[item.is]]">[[item.is]]</paper-tab>
             </template>
@@ -42,7 +42,6 @@ documentation page including demos (if available).
               <paper-tab value="[[item.is]]">[[item.is]]</paper-tab>
             </template>
           </paper-tabs>
-          </select>
         </div>
         <iron-selector attr-for-selected="view" selected="{{view}}" id="links" hidden$="[[!docDemos.length]]">
           <a view="docs"><iron-icon icon="description"></iron-icon> Docs</a>


### PR DESCRIPTION
There is a bug in safari <= 8 where the mousewheel event is not triggered inside an iframe : https://bugs.webkit.org/show_bug.cgi?id=124139
Therefore, any component demo that requires to listen to mousewheel events will not work on safari.
The fix uses a workaround found here : http://stackoverflow.com/questions/24642157/workaround-for-iframe-mousewheel-bug-in-safari-6-1-7-0

Thanks