### PR TITLE
Add deep linking

### DIFF
--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -427,6 +427,20 @@ documentation page including demos (if available).
           '_activeChanged(active, _analyzer)'
         ],
 
+        attached: function() {
+          // In the catalog, let the catalog do all the routing
+          if (!this.catalog) {
+            this._setActiveFromHash();
+            this.listen(window, 'hashchange', '_setActiveFromHash');
+          }
+        },
+
+        detached: function() {
+          if (!this.catalog) {
+            this.unlisten(window, 'hashchange', '_setActiveFromHash');
+          }
+        },
+
         ready: function() {
           var elements = this._loadJson();
           if (elements) {
@@ -437,14 +451,6 @@ documentation page including demos (if available).
             if (!this.src && !this.catalog) {
               this._srcChanged();
             }
-          }
-          // In the catalog, let the catalog do all the routing
-          if (!this.catalog) {
-            this._setActiveFromHash();
-            var boundSetActiveFromHash = this._setActiveFromHash.bind(this);
-            window.addEventListener('hashchange', function() {
-              boundSetActiveFromHash();
-            });
           }
         },
 

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -214,7 +214,7 @@ documentation page including demos (if available).
             <div id="catalog-heading" catalog-only>
               <h2><span>[[active]]</span> <span class="version" hidden$="[[!version]]">[[version]]</span></h2>
             </div>
-            <iron-doc-viewer id="viewer" descriptor="{{_activeDescriptor}}"
+            <iron-doc-viewer catalog="[[catalog]]" id="viewer" descriptor="{{_activeDescriptor}}"
               on-iron-doc-viewer-component-selected="_handleComponentSelectedEvent"></iron-doc-viewer>
             <div id="nodocs" hidden$="[[_activeDescriptor]]" class="no-docs">
               No documentation found.
@@ -428,7 +428,6 @@ documentation page including demos (if available).
         ],
 
         ready: function() {
-          console.log('in ready');
           var elements = this._loadJson();
           if (elements) {
             this.docElements = elements;
@@ -439,11 +438,14 @@ documentation page including demos (if available).
               this._srcChanged();
             }
           }
-          this._setActiveFromHash(window.location.hash);
-          var boundSetActiveFromHash = this._setActiveFromHash.bind(this);
-          window.addEventListener("hashchange", function() {
-            boundSetActiveFromHash(window.location.hash);
-          });
+          // In the catalog, let the catalog do all the routing
+          if (!this.catalog) {
+            this._setActiveFromHash(window.location.hash);
+            var boundSetActiveFromHash = this._setActiveFromHash.bind(this);
+            window.addEventListener("hashchange", function() {
+              boundSetActiveFromHash(window.location.hash);
+            });
+          }
         },
 
         /**
@@ -475,7 +477,6 @@ documentation page including demos (if available).
          */
 
         _setActiveFromHash(hash) {
-          console.log("iron-component-page:setActiveFromHash");
           // hash is either element-name or element-name:{properties|methods|events} or
           // element-name:{property|method|event}.member-name
           if (hash) {
@@ -483,7 +484,7 @@ documentation page including demos (if available).
             elementDelimiter = (elementDelimiter == -1) ? hash.length : elementDelimiter;
             var el = hash.slice(1, elementDelimiter);
             if (this.active == el) {
-              this.$.viewer.scrollToSelected();
+              this.$.viewer.scrollToAnchor();
             } else {
               this.active = el;
             }

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -194,7 +194,7 @@ documentation page including demos (if available).
       <paper-toolbar catalog-hidden>
         <div class="docs-header">
           <!-- TODO: Replace with paper-dropdown-menu when available -->
-          <select id="active" value="{{active::change}}">
+          <select id="active" value="[[active]]" on-change="_handleMenuItemSelected">
             <template is="dom-repeat" items="[[docElements]]">
               <option value="[[item.is]]">[[item.is]]</option>
             </template>
@@ -214,7 +214,7 @@ documentation page including demos (if available).
             <div id="catalog-heading" catalog-only>
               <h2><span>[[active]]</span> <span class="version" hidden$="[[!version]]">[[version]]</span></h2>
             </div>
-            <iron-doc-viewer descriptor="{{_activeDescriptor}}"
+            <iron-doc-viewer id="viewer" descriptor="{{_activeDescriptor}}"
               on-iron-doc-viewer-component-selected="_handleComponentSelectedEvent"></iron-doc-viewer>
             <div id="nodocs" hidden$="[[_activeDescriptor]]" class="no-docs">
               No documentation found.
@@ -428,6 +428,7 @@ documentation page including demos (if available).
         ],
 
         ready: function() {
+          console.log('in ready');
           var elements = this._loadJson();
           if (elements) {
             this.docElements = elements;
@@ -438,6 +439,11 @@ documentation page including demos (if available).
               this._srcChanged();
             }
           }
+          this._setActiveFromHash(window.location.hash);
+          var boundSetActiveFromHash = this._setActiveFromHash.bind(this);
+          window.addEventListener("hashchange", function() {
+            boundSetActiveFromHash(window.location.hash);
+          });
         },
 
         /**
@@ -461,6 +467,26 @@ documentation page including demos (if available).
           } catch(error) {
             console.error('Failure when parsing JSON:', textContent, error);
             throw error;
+          }
+        },
+
+        /**
+         * Load the page identified in the hash.
+         */
+
+        _setActiveFromHash(hash) {
+          console.log("iron-component-page:setActiveFromHash");
+          // hash is either element-name or element-name:{properties|methods|events} or
+          // element-name:{property|method|event}.member-name
+          if (hash) {
+            var elementDelimiter = hash.indexOf(':');
+            elementDelimiter = (elementDelimiter == -1) ? hash.length : elementDelimiter;
+            var el = hash.slice(1, elementDelimiter);
+            if (this.active == el) {
+              this.$.viewer.scrollToSelected();
+            } else {
+              this.active = el;
+            }
           }
         },
 
@@ -631,6 +657,12 @@ documentation page including demos (if available).
 
         _detectAnalyzer: function() {
           this._analyzer = this.docSrc ? this._ajaxDesc : this._hydroDesc;
+        },
+
+        _handleMenuItemSelected: function(e) {
+          if (e.target && e.target.value) {
+            window.location.hash = '#' + e.target.value;
+          }
         },
 
         _handleAjaxResponse: function(e, req) {

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -214,7 +214,7 @@ documentation page including demos (if available).
             <div id="catalog-heading" catalog-only>
               <h2><span>[[active]]</span> <span class="version" hidden$="[[!version]]">[[version]]</span></h2>
             </div>
-            <iron-doc-viewer catalog="[[catalog]]" id="viewer" descriptor="{{_activeDescriptor}}"
+            <iron-doc-viewer prefix="[[_fragmentPrefix]]" id="viewer" descriptor="{{_activeDescriptor}}"
               on-iron-doc-viewer-component-selected="_handleComponentSelectedEvent"></iron-doc-viewer>
             <div id="nodocs" hidden$="[[_activeDescriptor]]" class="no-docs">
               No documentation found.
@@ -440,10 +440,10 @@ documentation page including demos (if available).
           }
           // In the catalog, let the catalog do all the routing
           if (!this.catalog) {
-            this._setActiveFromHash(window.location.hash);
+            this._setActiveFromHash();
             var boundSetActiveFromHash = this._setActiveFromHash.bind(this);
-            window.addEventListener("hashchange", function() {
-              boundSetActiveFromHash(window.location.hash);
+            window.addEventListener('hashchange', function() {
+              boundSetActiveFromHash();
             });
           }
         },
@@ -473,21 +473,21 @@ documentation page including demos (if available).
         },
 
         /**
-         * Load the page identified in the hash.
+         * Load the page identified in the fragment identifier.
          */
 
         _setActiveFromHash(hash) {
           // hash is either element-name or element-name:{properties|methods|events} or
           // element-name:{property|method|event}.member-name
+          var hash = window.location.hash;
           if (hash) {
             var elementDelimiter = hash.indexOf(':');
             elementDelimiter = (elementDelimiter == -1) ? hash.length : elementDelimiter;
             var el = hash.slice(1, elementDelimiter);
-            if (this.active == el) {
-              this.$.viewer.scrollToAnchor();
-            } else {
+            if (this.active != el) {
               this.active = el;
             }
+            this.$.viewer.scrollToAnchor(hash);
           }
         },
 
@@ -613,6 +613,15 @@ documentation page including demos (if available).
               if (this._activeDescriptor.is && !document.title) {
                 document.title = this._activeDescriptor.is + " documentation";
               }
+              if (this._activeDescriptor.is && !this.catalog) {
+                this._fragmentPrefix = this._activeDescriptor.is + ':';
+              } else {
+                this._fragmentPrefix = '';
+              }
+              // On initial load, scroll to the selected anchor (if any).
+              // This probably shouldn't be required when we're running
+              // in the catalog, but at the moment it is.
+              this.$.viewer.scrollToAnchor(window.location.hash);
             }
             this._setDocDemos(this._activeDescriptor ? this._activeDescriptor.demos : []);
           }
@@ -634,26 +643,6 @@ documentation page including demos (if available).
           if (!this._findDescriptor(this.active)) {
             this.active = this._getDefaultActive();
           }
-
-          // Scroll to element. Wait one frame so for page load case. Browser
-          // will attempt to jump to the element before it exists in DOM.
-          // TODO: support scrolling to hidden API properties/methods.
-          // TODO: deep link into non-default "active" view in select dropdown.
-          this.async(function() {
-            var hash = window.location.hash;
-            if (hash) {
-              var goToElement = null;
-              // Find element using native shadow dom. Otherwise, fall back to shady.
-              if (Polymer.Settings.useNativeShadow) {
-                goToElement = this.$.view.querySelector(':scope /deep/ ' + hash);
-              } else {
-                goToElement = this.querySelector(hash);
-              }
-              if (goToElement) {
-                goToElement.scrollIntoView(true);
-              }
-            }
-          });
         },
 
         _detectAnalyzer: function() {


### PR DESCRIPTION
Fixes #28.

This may not be ready for prime time, but I'm going to leave it here as a proof-of-concept if nothing else.

Requires coordinating changes in [`iron-doc-viewer` PR#73](https://github.com/PolymerElements/iron-doc-viewer/pull/73).

Supports linking to various bits of the docs using the following URL hash formats:

    #element-name
    #element-name:properties (or methods, or events)
    #element-name:property.propertyName (or method, or event).

For example: `#dom-repeat:method.render`

@frankiefu @blasten PTAL