### PR TITLE
Rewrite _setActiveFromHash method definition to work with Safari 8

### DIFF
--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -482,7 +482,7 @@ documentation page including demos (if available).
          * Load the page identified in the fragment identifier.
          */
 
-        _setActiveFromHash(hash) {
+        _setActiveFromHash: function(hash) {
           // hash is either element-name or element-name:{properties|methods|events} or
           // element-name:{property|method|event}.member-name
           var hash = window.location.hash;


### PR DESCRIPTION
The current way it's written breaks in Safari 8.0.6

I didn't open a specific issue for this because it's such a small change.