### PR TITLE
add the `allowfullscreen` attribute to the iframe

### DIFF
--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -543,6 +543,7 @@ documentation page including demos (if available).
 
           this._iframe = document.createElement('iframe');
           this._iframe.src = demoSrc;
+          this._iframe.allowFullscreen = true;
           Polymer.dom(this.$.demo).appendChild(this._iframe);
         },
 


### PR DESCRIPTION
Currently, elements that utilize the Fullscreen API will not work in demo pages, because the `<iframe>` containing the element does not have the `allowfullscreen` attribute. 

This commit adds the attribute when the element is created. Going forward, elements that want to go full screen will work in demo pages.