### PR TITLE
make hover links pink

### DIFF
--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -85,8 +85,16 @@ documentation page including demos (if available).
         margin: -2px 5px 0 0;
       }
 
-      paper-toolbar a:hover, paper-toolbar a:hover iron-icon, paper-toolbar a.iron-selected, paper-toolbar a.iron-selected iron-icon {
+      paper-toolbar a.iron-selected, paper-toolbar a.iron-selected iron-icon {
         color: var(--paper-grey-800);
+      }
+
+      paper-toolbar a:hover, paper-toolbar a:hover iron-icon {
+        color: var(--paper-pink-500);
+      }
+
+      select {
+        cursor: pointer;
       }
 
       #demo iframe {


### PR DESCRIPTION
As a side note, this is what it looks like with the new `iron-doc-viewer` changes from https://github.com/PolymerElements/iron-doc-viewer/pull/80:

<img width="1355" alt="screen shot 2016-03-10 at 6 23 55 pm" src="https://cloud.githubusercontent.com/assets/1369170/13691386/468019e6-e6ed-11e5-8675-bf4807f5e900.png">
