### PR TITLE
add missing hidden style

### DIFF
--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -38,6 +38,10 @@ documentation page including demos (if available).
         background: var(--paper-grey-50);
       }
 
+      [hidden] {
+        display: none !important;
+      }
+
       p {
         max-width: 20em;
       }


### PR DESCRIPTION
In the shadow DOM, the `no-docs` `display:flex` style overrides the `hidden` user agent style and never actually gets hidden (see: http://jsbin.com/jinedo/edit?html,output)