### PR TITLE
Remove routing logic since iron-doc-viewer does it now.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#1 - 2",
     "iron-ajax": "PolymerElements/iron-ajax#1 - 2",
-    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#nav",
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#master",
     "iron-icons": "PolymerElements/iron-icons#1 - 2",
     "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
@@ -35,7 +35,7 @@
       "dependencies": {
         "app-layout": "PolymerElements/app-layout#^1.0.0",
         "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
-        "iron-doc-viewer": "PolymerElements/iron-doc-viewer#nav",
+        "iron-doc-viewer": "PolymerElements/iron-doc-viewer#master",
         "iron-icons": "PolymerElements/iron-icons#^1.0.0",
         "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -18,7 +18,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-doc-viewer/iron-doc-viewer-default-theme.html">
 <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
-<link rel="import" href="../iron-location/iron-location.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/typography.html">
@@ -61,8 +60,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <iron-location hash="{{_urlHash}}"></iron-location>
-
     <iron-ajax
         auto
         url="[[descriptorUrl]]"
@@ -85,8 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer id="drawer" slot="drawer" swipe-open>
         <iron-doc-nav
             descriptor="[[_descriptor]]"
-            path="{{_path}}"
-            base-href="#"
+            path="[[_path]]"
             on-select="_onNavSelect">
         </iron-doc-nav>
       </app-drawer>
@@ -100,12 +96,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </app-header>
 
         <iron-doc-viewer
-            id="viewer"
             descriptor="[[_descriptor]]"
             title="{{_title}}"
-            path="[[_path]]"
-            fragment-prefix="[[_path]]#"
-            scroll-to="[[_scrollTo]]">
+            path="{{_path}}">
         </iron-doc-viewer>
 
       </app-header-layout>
@@ -137,14 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           _title: {
             type: String,
             observer: '_titleChanged'
-          },
-
-          _urlHash: {
-            type: String,
-            observer: '_urlHashChanged'
-          },
-
-          _scrollTo: String
+          }
         },
 
         _onNavSelect() {
@@ -167,9 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._descriptor = _flatten(descriptor);
           this._changing = false;
 
-          if (this._urlHash) {
-            return;
-          }
+          return;
 
           var behaviors = descriptor.metadata
               && descriptor.metadata.polymer
@@ -191,12 +175,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         _titleChanged(title) {
           window.document.title = title;
-        },
-
-        _urlHashChanged(urlHash) {
-          var parts = urlHash.split('#');
-          this._path = parts[0];
-          this._scrollTo = parts[1];
         }
       });
 

--- a/iron-component-page.html
+++ b/iron-component-page.html
@@ -86,7 +86,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <iron-doc-nav
             descriptor="[[_descriptor]]"
             path="{{_path}}"
-            on-select="_clearScroll">
+            base-href="#"
+            on-select="_onNavSelect">
         </iron-doc-nav>
       </app-drawer>
 
@@ -131,10 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             observer: '_descriptorChanged'
           },
 
-          _path: {
-            type: String,
-            observer: '_pathChanged'
-          },
+          _path: String,
 
           _title: {
             type: String,
@@ -146,19 +144,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             observer: '_urlHashChanged'
           },
 
-          _scrollTo: String,
-
-          _changing: {
-            type: Boolean,
-            value: false
-          }
+          _scrollTo: String
         },
 
-        _clearScroll() {
+        _onNavSelect() {
           document.body.scrollTop = 0;
-          var pos = this._urlHash.indexOf('#');
-          if (pos >= 0) {
-            this._urlHash = this._urlHash.substring(0, pos);
+          if (this.$.layout.narrow) {
+            this.$.drawer.close();
           }
         },
 
@@ -197,31 +189,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         },
 
-        _pathChanged(path) {
-          if (this._changing) {
-            return;
-          }
-          this._changing = true;
-          this._urlHash = path;
-          this._changing = false;
-          if (this.$.layout.narrow) {
-            this.$.drawer.close();
-          }
-        },
-
         _titleChanged(title) {
           window.document.title = title;
         },
 
         _urlHashChanged(urlHash) {
-          if (this._changing) {
-            return;
-          }
           var parts = urlHash.split('#');
-          this._changing = true;
           this._path = parts[0];
           this._scrollTo = parts[1];
-          this._changing = false;
         }
       });
 


### PR DESCRIPTION
See https://github.com/PolymerElements/iron-doc-viewer/pull/141 for context.

(I wish this was one repo).