### PR TITLE
Prepare release of iron-component-page 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,6 @@
 
 ## &lt;iron-component-page&gt;
 
-***
-⚠️ The version of `iron-component-page` described below is coming soon, but not
-quite yet tagged for release. You can checkout the `master` branch to
-experiment with it now. See [this
-issue](https://github.com/PolymerElements/iron-component-page/issues/121) for
-status. ⚠️
-***
-
 `iron-component-page` is a full-page documentation browser for custom elements,
 mixins, classes, and more. It consumes the JSON descriptor format produced by
 [Polymer Analyzer](https://github.com/Polymer/polymer-analyzer).
@@ -102,6 +94,8 @@ predecessor to Polymer Analyzer. Major changes in the 3.x version include:
   to generate an `analysis.json` file offline.
 * Replaces the element menu with a full-size navigation panel that summarizes
   all the available documentation produced by Polymer Analyzer.
+* Uses the 3.x version of the
+  [`iron-doc` elements](https://github.com/PolymerElements/iron-doc-viewer).
 
 If you still need the previous version, see the
 [2.x branch](https://github.com/PolymerElements/iron-component-page/tree/2.x).

--- a/bower.json
+++ b/bower.json
@@ -13,13 +13,13 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/iron-component-page.git"
   },
-  "version": "2.0.0",
+  "version": "3.0.0",
   "private": true,
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#1 - 2",
     "iron-ajax": "PolymerElements/iron-ajax#1 - 2",
-    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#>=3.0.0-rc.1",
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^3.0.0",
     "iron-icons": "PolymerElements/iron-icons#1 - 2",
     "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
@@ -35,7 +35,7 @@
       "dependencies": {
         "app-layout": "PolymerElements/app-layout#^1.0.0",
         "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
-        "iron-doc-viewer": "PolymerElements/iron-doc-viewer#>=3.0.0-rc.1",
+        "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^3.0.0",
         "iron-icons": "PolymerElements/iron-icons#^1.0.0",
         "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",


### PR DESCRIPTION
When this PR is merged, I'll tag the final 3.0.0 release of `iron-component-page` and `iron-doc-viewer`. If there are any issues or questions that should block the release, let's discuss here.

See the summary of changes at the bottom of the README.

Live demos:
- Polymer 2 core: https://aomarks-test-docs.appspot.com
- app-layout: https://aomarks-test-docs.appspot.com/app-layout.html